### PR TITLE
Force anonymous

### DIFF
--- a/liste-envies-war/src/main/java/fr/desaintsteban/liste/envies/dto/WishListDto.java
+++ b/liste-envies-war/src/main/java/fr/desaintsteban/liste/envies/dto/WishListDto.java
@@ -30,6 +30,10 @@ public class WishListDto {
     private Date date; // date of the event
     private SharingPrivacyType privacy; // Option for sharing privacy of the all list.
 
+
+
+    private boolean forceAnonymus = false; // To force display list as anonymous. for owner it will show the list as anonyme.
+
     private WishListState state;
 
     private Boolean canSuggest;
@@ -128,5 +132,14 @@ public class WishListDto {
 
     public void setCanSuggest(Boolean canSuggest) {
         this.canSuggest = canSuggest;
-    }  
+    }
+
+    public boolean isForceAnonymus() {
+        return forceAnonymus;
+    }
+
+    public void setForceAnonymus(boolean forceAnonymus) {
+        this.forceAnonymus = forceAnonymus;
+    }
+
 }

--- a/liste-envies-war/src/main/java/fr/desaintsteban/liste/envies/model/WishList.java
+++ b/liste-envies-war/src/main/java/fr/desaintsteban/liste/envies/model/WishList.java
@@ -88,6 +88,9 @@ public class WishList {
         setType( dto.getType());
         setDate( dto.getDate());
         setPrivacy( dto.getPrivacy());
+
+        setForceAnonymus(dto.isForceAnonymus());
+
     }
 
     public WishListDto toDto() {
@@ -100,6 +103,7 @@ public class WishList {
         dto.setDate( getDate());
         dto.setPrivacy( getPrivacy());
         dto.setOwner(false);
+        dto.setForceAnonymus(isForceAnonymus());
         return dto;
     }
 

--- a/liste-envies-war/src/main/java/fr/desaintsteban/liste/envies/model/WishList.java
+++ b/liste-envies-war/src/main/java/fr/desaintsteban/liste/envies/model/WishList.java
@@ -36,6 +36,9 @@ public class WishList {
     private SharingPrivacyType privacy; // Option for sharing privacy of the all list.
 
 
+    private boolean forceAnonymus = false; // To force display list as anonymous. for owner it will show the list as anonyme.
+
+
     public WishList() {
         this.privacy = SharingPrivacyType.PRIVATE;
     }
@@ -180,5 +183,14 @@ public class WishList {
     public void addUser(AppUser user) {
         if (users == null) users = new ArrayList<>();
         users.add(new UserShare(user.getEmail(), UserShareType.SHARED));
+    }
+
+
+    public boolean isForceAnonymus() {
+        return forceAnonymus;
+    }
+
+    public void setForceAnonymus(boolean forceAnonymus) {
+        this.forceAnonymus = forceAnonymus;
     }
 }

--- a/liste-envies-war/src/main/java/fr/desaintsteban/liste/envies/util/WishRules.java
+++ b/liste-envies-war/src/main/java/fr/desaintsteban/liste/envies/util/WishRules.java
@@ -321,14 +321,17 @@ public class WishRules {
             case ANONYMOUS:
                 if (wish.getUserTake() == null || wish.getUserTake().isEmpty()) {
                     wish.setUserTake(null);
+                    wish.setGiven(wish.getAllreadyGiven());
                 } else {
                     PersonParticipantDto anymous = new PersonParticipantDto("", "", "", "");
                     ArrayList<PersonParticipantDto> userTake = new ArrayList<>();
                     userTake.add(anymous);
                     wish.setUserTake(userTake);
+                    wish.setGiven(true);
+                    wish.setUserGiven(true);
                 }
 
-                wish.setGiven(wish.getAllreadyGiven());
+
                 if (!ListUtils.isNullOrEmpty(wish.getComments())) {
                     wish.setComments(wish.getComments().stream().filter(comment -> comment.getType() == CommentType.PUBLIC).collect(toList()));
                 }

--- a/liste-envies-war/src/main/java/fr/desaintsteban/liste/envies/util/WishRules.java
+++ b/liste-envies-war/src/main/java/fr/desaintsteban/liste/envies/util/WishRules.java
@@ -238,8 +238,11 @@ public class WishRules {
         WishListState state = computeWishListState(user, list);
         switch (state) {
             case OWNER:
+                if (list.isForceAnonymus()) {
+                    return WishOptionType.ANONYMOUS;
+                }
                 //Si une options est définie dans la liste, alors c'est l'option par défaut
-                if (list.getPrivacy() != null) {
+                else if (list.getPrivacy() != null) {
                     switch (list.getPrivacy()) {
                         case PRIVATE:
                             return WishOptionType.HIDDEN;
@@ -316,7 +319,15 @@ public class WishRules {
                 }
                 break;
             case ANONYMOUS:
-                wish.setUserTake(null);
+                if (wish.getUserTake() == null || wish.getUserTake().isEmpty()) {
+                    wish.setUserTake(null);
+                } else {
+                    PersonParticipantDto anymous = new PersonParticipantDto("", "", "", "");
+                    ArrayList<PersonParticipantDto> userTake = new ArrayList<>();
+                    userTake.add(anymous);
+                    wish.setUserTake(userTake);
+                }
+
                 wish.setGiven(wish.getAllreadyGiven());
                 if (!ListUtils.isNullOrEmpty(wish.getComments())) {
                     wish.setComments(wish.getComments().stream().filter(comment -> comment.getType() == CommentType.PUBLIC).collect(toList()));

--- a/liste-envies-war/src/main/java/fr/desaintsteban/liste/envies/util/WishRules.java
+++ b/liste-envies-war/src/main/java/fr/desaintsteban/liste/envies/util/WishRules.java
@@ -323,12 +323,11 @@ public class WishRules {
                     wish.setUserTake(null);
                     wish.setGiven(wish.getAllreadyGiven());
                 } else {
-                    PersonParticipantDto anymous = new PersonParticipantDto("", "", "", "");
+                    PersonParticipantDto anymous = new PersonParticipantDto("", "anonyme", "", "");
                     ArrayList<PersonParticipantDto> userTake = new ArrayList<>();
                     userTake.add(anymous);
                     wish.setUserTake(userTake);
                     wish.setGiven(true);
-                    wish.setUserGiven(true);
                 }
 
 

--- a/liste-envies-war/src/main/webapp/js/lang/fr-FR.json
+++ b/liste-envies-war/src/main/webapp/js/lang/fr-FR.json
@@ -178,6 +178,7 @@
       "PUBLIC": "La liste peut être affiché sans être connecté par toute personne connaissant le lien. Il est nécessaire de se connecter pour interagir avec, et voir si une envie est prise. <br/> Toutes les personnes connectés (bénéficiaires compris) voient qui donne une envie.",
       "DEFAULT": "Selectionnez la visibilité de la liste"
     },
+    "FORCE_ANONYMOUS": "Afficher de manière anonyme si l'envies est déjà offerte.",
     "DATE": "Date de l'événement",
     "DATE_INFO": "Pour afficher un compte à rebours jusqu'à l'événement"
   },

--- a/liste-envies-war/src/main/webapp/templates/directive/WishListSettings.html
+++ b/liste-envies-war/src/main/webapp/templates/directive/WishListSettings.html
@@ -58,4 +58,9 @@
             <span ng-switch-default  translate=".DESCRIPTION.DEFAULT">...</span>
         </div>
     </div>
+    <div class="form-group">
+
+        <input type="checkbox" class="form-control" id="force-anonymous" ng-model="w.wishList.forceAnonymus">
+        <label for="force-anonymous">force anonymous</label>
+    </div>
 </div>

--- a/liste-envies-war/src/main/webapp/templates/directive/WishListSettings.html
+++ b/liste-envies-war/src/main/webapp/templates/directive/WishListSettings.html
@@ -60,7 +60,7 @@
     </div>
     <div class="form-group">
 
-        <input type="checkbox" class="form-control" id="force-anonymous" ng-model="w.wishList.forceAnonymus">
-        <label for="force-anonymous">force anonymous</label>
+
+        <label ><input type="checkbox" id="force-anonymous" ng-model="w.wishList.forceAnonymus"> <span translate=".FORCE_ANONYMOUS"></span></label>
     </div>
 </div>

--- a/liste-envies-war/src/test/java/fr/desaintsteban/liste/envies/util/WishRulesTest.java
+++ b/liste-envies-war/src/test/java/fr/desaintsteban/liste/envies/util/WishRulesTest.java
@@ -23,7 +23,7 @@ public class WishRulesTest {
 
         WishDto cleaned = WishRules.cleanWish(wish, WishOptionType.ANONYMOUS);
 
-        assertThat(cleaned.getUserTake()).isNull();
+        assertThat(cleaned.getUserTake()).hasSize(1);
         assertThat(cleaned.getComments()).hasSize(1).onProperty("text").contains("Public");
     }
 


### PR DESCRIPTION
permettre d'afficher en mode anonyme si l'envie est donnée. Ajoute une options dans la liste pour afficher en mode anonyme si une envie est donnée. (marque :  "offert par anonyme").  Option disponible pour tous les privacy de listes. 