### PR TITLE
:bug: Fix forceAnonymous option forgiven in WishList entity

### DIFF
--- a/liste-envies-war/src/main/java/fr/desaintsteban/liste/envies/dto/WishListDto.java
+++ b/liste-envies-war/src/main/java/fr/desaintsteban/liste/envies/dto/WishListDto.java
@@ -31,7 +31,7 @@ public class WishListDto {
     private WishListType type; // Purpose of the event for this list
     private Date date; // date of the event
     private SharingPrivacyType privacy; // Option for sharing privacy of the all list.
-
+    private Boolean forceAnonymous;
     private WishListState state;
 
     private Boolean canSuggest;
@@ -116,6 +116,14 @@ public class WishListDto {
 
     public void setPrivacy(SharingPrivacyType privacy) {
         this.privacy = privacy;
+    }
+
+    public Boolean getForceAnonymous() {
+        return forceAnonymous;
+    }
+
+    public void setForceAnonymous(Boolean forceAnonymous) {
+        this.forceAnonymous = forceAnonymous;
     }
 
     public WishListState getState() {

--- a/liste-envies-war/src/main/java/fr/desaintsteban/liste/envies/model/WishList.java
+++ b/liste-envies-war/src/main/java/fr/desaintsteban/liste/envies/model/WishList.java
@@ -2,6 +2,7 @@ package fr.desaintsteban.liste.envies.model;
 
 import com.google.common.annotations.VisibleForTesting;
 import com.googlecode.objectify.Key;
+import com.googlecode.objectify.annotation.AlsoLoad;
 import com.googlecode.objectify.annotation.Cache;
 import com.googlecode.objectify.annotation.Entity;
 import com.googlecode.objectify.annotation.Id;
@@ -39,6 +40,9 @@ public class WishList {
     private WishListType type; // Purpose of the event for this list
     private Date date; // date of the event
     private SharingPrivacyType privacy; // Option for sharing privacy of the all list.
+    @AlsoLoad("forceAnonymus")
+    private Boolean forceAnonymous = false;
+
     @Embedded
     @Index
     private HashMap<WishState, Integer> counts = new HashMap<>(); //Compte le nombre d'envies dans chaque état
@@ -90,10 +94,11 @@ public class WishList {
         setDescription(dto.getDescription());
         List<UserShare> users = dto.getUsers().stream().map(userShareDto -> new UserShare(userShareDto.getEmail(), userShareDto.getType())).collect(Collectors.toList());
         setUsers(users);
-        setPicture( dto.getPicture());
-        setType( dto.getType());
-        setDate( dto.getDate());
-        setPrivacy( dto.getPrivacy());
+        setPicture(dto.getPicture());
+        setType(dto.getType());
+        setDate(dto.getDate());
+        setPrivacy(dto.getPrivacy());
+        setForceAnonymous(dto.getForceAnonymous() );
         setStatus(dto.getStatus());
     }
 
@@ -102,10 +107,11 @@ public class WishList {
         dto.setName(getName());
         dto.setTitle(getTitle());
         dto.setDescription(getDescription());
-        dto.setPicture( getPicture());
-        dto.setType( getType());
-        dto.setDate( getDate());
-        dto.setPrivacy( getPrivacy());
+        dto.setPicture(getPicture());
+        dto.setType(getType());
+        dto.setDate(getDate());
+        dto.setPrivacy(getPrivacy());
+        dto.setForceAnonymous(getForceAnonymous());
         dto.setOwner(false);
         dto.setCounts(getCounts());
         dto.setStatus(getStatus());
@@ -175,6 +181,14 @@ public class WishList {
 
     public void setPrivacy(SharingPrivacyType privacy) {
         this.privacy = privacy;
+    }
+
+    public Boolean getForceAnonymous() {
+        return forceAnonymous;
+    }
+
+    public void setForceAnonymous(Boolean forceAnonymous) {
+        this.forceAnonymous = forceAnonymous;
     }
 
     public boolean containsOwner(String email) {

--- a/liste-envies-war/src/main/java/fr/desaintsteban/liste/envies/util/WishRules.java
+++ b/liste-envies-war/src/main/java/fr/desaintsteban/liste/envies/util/WishRules.java
@@ -18,6 +18,7 @@ import fr.desaintsteban.liste.envies.service.AppUserService;
 import fr.desaintsteban.liste.envies.service.WishListService;
 
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -256,8 +257,11 @@ public class WishRules {
         WishListState state = computeWishListState(user, list);
         switch (state) {
             case OWNER:
+                if (list.getForceAnonymous()) {
+                    return WishOptionType.ANONYMOUS;
+                }
                 //Si une options est définie dans la liste, alors c'est l'option par défaut
-                if (list.getPrivacy() != null) {
+                else if (list.getPrivacy() != null) {
                     switch (list.getPrivacy()) {
                         case PRIVATE:
                             return WishOptionType.HIDDEN;
@@ -333,8 +337,15 @@ public class WishRules {
                 }
                 break;
             case ANONYMOUS:
-                wish.setUserTake(null);
-                wish.setGiven(wish.getAllreadyGiven());
+                if (wish.getUserTake() == null || wish.getUserTake().isEmpty()) {
+                    wish.setUserTake(null);
+                    wish.setGiven(wish.getAllreadyGiven());
+                } else {
+                    PersonParticipantDto anonymous = new PersonParticipantDto("", "anonyme", "", "", "");
+                    wish.setUserTake(Arrays.asList(anonymous));
+                    wish.setGiven(true);
+                    wish.setUserGiven(true);
+                }
                 if (ListUtils.isNotEmpty(wish.getComments())) {
                     wish.setComments(wish.getComments().stream().filter(comment -> comment.getType() == CommentType.PUBLIC).collect(toList()));
                 }

--- a/liste-envies-war/src/test/java/fr/desaintsteban/liste/envies/util/WishRulesTest.java
+++ b/liste-envies-war/src/test/java/fr/desaintsteban/liste/envies/util/WishRulesTest.java
@@ -24,7 +24,7 @@ public class WishRulesTest {
 
         WishDto cleaned = WishRules.cleanWish(wish, WishOptionType.ANONYMOUS);
 
-        assertThat(cleaned.getUserTake()).isNull();
+        assertThat(extractProperty("name").from(cleaned.getUserTake())).hasSize(1).contains("anonyme");
         assertThat(extractProperty("text").from(cleaned.getComments())).hasSize(1).contains("Public");
     }
 


### PR DESCRIPTION
L'options forceAnonymous n'était plus dans l'entité WishList, ce qui fait que l'option n'était plus possible.
De plus, dans l'ancienne version, la propriété était forceAnonymus.