### PR TITLE
Hotfix/#119 deja recue offrir

### DIFF
--- a/liste-envies-front/src/app/app-routing.module.ts
+++ b/liste-envies-front/src/app/app-routing.module.ts
@@ -55,11 +55,10 @@ const routes: Routes = [
       {
         path: ":listId",
         resolve: {
-          whishList: WishListResolver,
-          whishesItems: WishListItemsResolver
+          whishList: WishListResolver
         },
         children: [
-          { path: "", component: ListComponent },
+          { path: "", redirectTo: "toOffer", pathMatch: "full" },
           {
             path: "edit",
             resolve: {
@@ -75,6 +74,13 @@ const routes: Routes = [
             },
             component: ListComponent,
             canActivate: [IsConnectedGuard]
+          },
+          {
+            path: "toOffer",
+            resolve: {
+              whishesItems: WishListItemsResolver
+            },
+            component: ListComponent
           }
         ]
       }

--- a/liste-envies-front/src/app/models/WishList.d.ts
+++ b/liste-envies-front/src/app/models/WishList.d.ts
@@ -13,7 +13,11 @@
   state?: string;
   owner?: boolean;
   canSuggest?: boolean;
-  counts?: { [key: string]: number };
+  counts?: {
+    ACTIVE: number;
+    ARCHIVED: number;
+    [key: string]: number;
+  };
 }
 
 export interface UserShare {

--- a/liste-envies-front/src/app/page/list/list.component.html
+++ b/liste-envies-front/src/app/page/list/list.component.html
@@ -1,8 +1,5 @@
 <div class="page-all">
-  <div
-    class="page-background"
-    [style.backgroundImage]="listBackgroundImg()"
-  ></div>
+  <div class="page-background" [style.backgroundImage]="backgroundImage"></div>
   <mat-menu #menu="matMenu">
     <button mat-menu-item routerLink="edit" color="accent">
       <mat-icon>edit</mat-icon>
@@ -141,11 +138,10 @@
         <a
           mat-tab-link
           class="tab"
-          [routerLink]="['/', list.name]"
+          [routerLink]="['/', list.name, 'toOffer']"
           routerLinkActive
           #currentList="routerLinkActive"
           [active]="currentList.isActive"
-          [routerLinkActiveOptions]="{ exact: true }"
           (click)="onClickTabGive($event, currentList.isActive)"
           matTooltip="Afficher les envies en cours de la liste offertes ou qui reste à offrir"
         >
@@ -153,8 +149,9 @@
             class="tab-icon"
             [matBadge]="list?.counts?.ACTIVE"
             matBadgeSize="small"
-            >card_giftcard</mat-icon
           >
+            card_giftcard
+          </mat-icon>
           A offrir
         </a>
         <a
@@ -164,7 +161,7 @@
           routerLinkActive
           #archiveList="routerLinkActive"
           [active]="archiveList.isActive"
-          (click)="onClickTabGive($event, archiveList.isActive)"
+          (click)="onClickTabArchive($event, archiveList.isActive)"
           matTooltip="Afficher les envies de cette liste qui ont déjà été offertes et qui ont été archivées"
           *ngIf="list?.counts?.ARCHIVED > 0"
         >
@@ -172,8 +169,9 @@
             class="tab-icon"
             [matBadge]="list?.counts?.ARCHIVED"
             matBadgeSize="small"
-            >history</mat-icon
           >
+            history
+          </mat-icon>
           Archivé (Déjà reçu)
         </a>
       </nav>

--- a/liste-envies-front/src/app/page/list/list.component.html
+++ b/liste-envies-front/src/app/page/list/list.component.html
@@ -174,6 +174,16 @@
           </mat-icon>
           Archivé (Déjà reçu)
         </a>
+
+        <a
+          mat-tab-link
+          class="tab refresh-button"
+          (click)="refreshList()"
+          matTooltip="Recharger la liste"
+        >
+          <mat-icon class="tab-icon"> refresh </mat-icon>
+          Rafraichir
+        </a>
       </nav>
     </div>
   </mat-expansion-panel>

--- a/liste-envies-front/src/app/page/list/list.component.html
+++ b/liste-envies-front/src/app/page/list/list.component.html
@@ -149,7 +149,12 @@
           (click)="onClickTabGive($event, currentList.isActive)"
           matTooltip="Afficher les envies en cours de la liste offertes ou qui reste à offrir"
         >
-          <mat-icon class="tab-icon">card_giftcard</mat-icon>
+          <mat-icon
+            class="tab-icon"
+            [matBadge]="list?.counts?.ACTIVE"
+            matBadgeSize="small"
+            >card_giftcard</mat-icon
+          >
           A offrir
         </a>
         <a
@@ -161,8 +166,14 @@
           [active]="archiveList.isActive"
           (click)="onClickTabGive($event, archiveList.isActive)"
           matTooltip="Afficher les envies de cette liste qui ont déjà été offertes et qui ont été archivées"
+          *ngIf="list?.counts?.ARCHIVED > 0"
         >
-          <mat-icon class="tab-icon">history</mat-icon>
+          <mat-icon
+            class="tab-icon"
+            [matBadge]="list?.counts?.ARCHIVED"
+            matBadgeSize="small"
+            >history</mat-icon
+          >
           Archivé (Déjà reçu)
         </a>
       </nav>

--- a/liste-envies-front/src/app/page/list/list.component.scss
+++ b/liste-envies-front/src/app/page/list/list.component.scss
@@ -53,22 +53,20 @@ mat-divider.mat-divider.divider-withDate.mat-divider-horizontal.mat-divider-inse
   .header-wishlist-menu {
     max-height: 3em;
     flex-direction: row-reverse;
-
-    nav.tabs-actif-archive {
-      .tab {
-        display: flex;
-        justify-content: space-around;
-        align-items: center;
-
-        .tab-icon {
-          font-size: 14px;
-          margin-top: 8px;
-        }
-      }
-    }
   }
+}
 
-  .menu-admin-list-button {
+.tabs-actif-archive {
+  .tab {
+    display: flex;
+    justify-content: space-around;
+    align-items: center;
+
+    .tab-icon {
+      font-size: 14px;
+      margin-top: 8px;
+      margin-right: 15px;
+    }
   }
 }
 

--- a/liste-envies-front/src/app/page/list/list.component.scss
+++ b/liste-envies-front/src/app/page/list/list.component.scss
@@ -67,6 +67,10 @@ mat-divider.mat-divider.divider-withDate.mat-divider-horizontal.mat-divider-inse
       margin-top: 8px;
       margin-right: 15px;
     }
+
+    &.refresh-button {
+      margin-left: auto;
+    }
   }
 }
 

--- a/liste-envies-front/src/app/page/list/list.component.ts
+++ b/liste-envies-front/src/app/page/list/list.component.ts
@@ -47,6 +47,8 @@ export class ListComponent implements OnInit, OnChanges {
 
   loading$: Observable<boolean>;
 
+  backgroundImage: string;
+
   @Input()
   list: WishList;
 
@@ -96,11 +98,14 @@ export class ListComponent implements OnInit, OnChanges {
         distinct(),
         tap(wishList => {
           this.list = wishList;
-        }),
-        distinctUntilKeyChanged("picture")
+        })
       )
       .subscribe(() => {
-        this.colorManagementService.setColorFromUrl(this.getUrlImage());
+        let backgroundImageTemp = this.listBackgroundImg();
+        if (backgroundImageTemp !== this.backgroundImage) {
+          this.backgroundImage = backgroundImageTemp;
+          this.colorManagementService.setColorFromUrl(this.getUrlImage());
+        }
       });
 
     this.listItems = this.wishQuery.selectAll();
@@ -178,9 +183,15 @@ export class ListComponent implements OnInit, OnChanges {
   }
 
   onClickTabGive(event, isActive) {
-    if (!isActive) {
-      this.wishService.setLoading();
-    }
+    /*if (!isActive) {
+      this.wishService.displayActive();
+    }*/
+  }
+
+  onClickTabArchive(event, isActive) {
+    /*if (!isActive) {
+      this.wishService.displayArchive();
+    }*/
   }
 
   doNothing(event) {

--- a/liste-envies-front/src/app/page/list/list.component.ts
+++ b/liste-envies-front/src/app/page/list/list.component.ts
@@ -113,15 +113,17 @@ export class ListComponent implements OnInit, OnChanges {
 
     this.userAuth.pipe(skip(1), untilDestroyed(this)).subscribe(value => {
       if (value) {
-        this.loadList();
+        this.refreshList();
       }
     });
   }
 
-  private loadList() {
+  public refreshList() {
     if (this.demo) return;
-
-    this.wishService.get(this.route.snapshot.params["listId"], false);
+    this.wishService.refresh(
+      this.route.snapshot.url.join(""),
+      this.route.snapshot.params["listId"]
+    );
   }
 
   addWish() {

--- a/liste-envies-front/src/app/page/received/received.component.ts
+++ b/liste-envies-front/src/app/page/received/received.component.ts
@@ -56,7 +56,6 @@ export class ReceivedComponent implements OnInit {
   }
 
   private loadList() {
-    console.log("loadlist");
     this.wishService.getReceived(false);
   }
 }

--- a/liste-envies-front/src/app/service/wishListItemsResolve.ts
+++ b/liste-envies-front/src/app/service/wishListItemsResolve.ts
@@ -13,7 +13,6 @@ export class WishListItemsResolver implements Resolve<boolean> {
   constructor(private router: Router, private wishService: WishService) {}
 
   resolve(route: ActivatedRouteSnapshot, state: RouterStateSnapshot): boolean {
-    console.log("Wish list get items :", route.params.listId);
     this.wishService.get(route.params.listId);
     return true;
   }

--- a/liste-envies-front/src/app/service/wishListItemsResolve.ts
+++ b/liste-envies-front/src/app/service/wishListItemsResolve.ts
@@ -13,6 +13,7 @@ export class WishListItemsResolver implements Resolve<boolean> {
   constructor(private router: Router, private wishService: WishService) {}
 
   resolve(route: ActivatedRouteSnapshot, state: RouterStateSnapshot): boolean {
+    console.log("Wish list get items :", route.params.listId);
     this.wishService.get(route.params.listId);
     return true;
   }

--- a/liste-envies-front/src/app/shared/img-form/img-form.component.ts
+++ b/liste-envies-front/src/app/shared/img-form/img-form.component.ts
@@ -71,8 +71,6 @@ export class ImgFormComponent implements OnInit {
   }
 
   pondHandleAddFile(event: any) {
-    console.log("pound Handle add file", event);
-
     this.addImg(event.file.getFileEncodeDataURL());
     if (!event.error && !event.status) {
       this.myPond.removeFile(event.file.id);

--- a/liste-envies-front/src/app/state/wishes/wish.query.ts
+++ b/liste-envies-front/src/app/state/wishes/wish.query.ts
@@ -27,4 +27,16 @@ export class WishQuery extends QueryEntity<WishState> {
   selectWish() {
     return this.select().pipe(pluck<WishState, WishList>("wishList"));
   }
+
+  isFullWishListLoaded(): boolean {
+    return this.getValue().ui.loaded.full;
+  }
+
+  isToOfferListLoaded(): boolean {
+    return this.getValue().ui.loaded.toOffer;
+  }
+
+  isArchiveListLoaded(): boolean {
+    return this.getValue().ui.loaded.archive;
+  }
 }

--- a/liste-envies-front/src/app/state/wishes/wish.store.ts
+++ b/liste-envies-front/src/app/state/wishes/wish.store.ts
@@ -34,13 +34,22 @@ export class WishStore extends EntityStore<WishState> {
     });
   }
 
+  @action("set to reload")
+  setReload() {
+    this.update(state => {
+      state = _.merge({}, state, {
+        ui: { loaded: { full: false, toOffer: false, archive: false } }
+      });
+      return state;
+    });
+  }
+
   @action("loaded toOffer")
   setLoadedToFull(isFull: boolean) {
     this.update(state => {
       state = _.merge({}, state, {
         ui: { loaded: { full: isFull } }
       });
-      console.log("setLoaded to offer : ", state);
       return state;
     });
   }
@@ -51,7 +60,6 @@ export class WishStore extends EntityStore<WishState> {
       state = _.merge({}, state, {
         ui: { loaded: { toOffer: true } }
       });
-      console.log("setLoaded to offer : ", state);
       return state;
     });
   }
@@ -61,7 +69,6 @@ export class WishStore extends EntityStore<WishState> {
       state = _.merge({}, state, {
         ui: { loaded: { archive: true } }
       });
-      console.log("setLoaded to archive : ", state);
       return state;
     });
   }

--- a/liste-envies-front/src/app/state/wishes/wish.store.ts
+++ b/liste-envies-front/src/app/state/wishes/wish.store.ts
@@ -1,5 +1,6 @@
 import { Injectable } from "@angular/core";
 import {
+  action,
   ActiveState,
   EntityState,
   EntityStore,
@@ -7,16 +8,61 @@ import {
 } from "@datorama/akita";
 import { WishList } from "../../models/WishList";
 import { WishItem } from "../../models/WishItem";
+import { state } from "@angular/animations";
+import * as _ from "lodash";
 
 export interface WishState extends EntityState<WishItem>, ActiveState {
   wishList: WishList;
-  ui: {};
+  ui: {
+    loaded: {
+      full: boolean;
+      toOffer: boolean;
+      archive: boolean;
+    };
+  };
 }
 
 @Injectable({ providedIn: "root" })
 @StoreConfig({ name: "wish" })
 export class WishStore extends EntityStore<WishState> {
   constructor() {
-    super();
+    super({
+      wishList: null,
+      ui: {
+        loaded: { full: false, toOffer: false, archive: false }
+      }
+    });
+  }
+
+  @action("loaded toOffer")
+  setLoadedToFull(isFull: boolean) {
+    this.update(state => {
+      state = _.merge({}, state, {
+        ui: { loaded: { full: isFull } }
+      });
+      console.log("setLoaded to offer : ", state);
+      return state;
+    });
+  }
+
+  @action("loaded toOffer")
+  setLoadedToOffer() {
+    this.update(state => {
+      state = _.merge({}, state, {
+        ui: { loaded: { toOffer: true } }
+      });
+      console.log("setLoaded to offer : ", state);
+      return state;
+    });
+  }
+  @action("loaded archive")
+  setLoadedArchive() {
+    this.update(state => {
+      state = _.merge({}, state, {
+        ui: { loaded: { archive: true } }
+      });
+      console.log("setLoaded to archive : ", state);
+      return state;
+    });
   }
 }

--- a/liste-envies-front/src/app/state/wishes/wishes-list.service.ts
+++ b/liste-envies-front/src/app/state/wishes/wishes-list.service.ts
@@ -72,18 +72,11 @@ export class WishesListService {
     ) {
       const listActive = this.wishesListQuery.getActive() as WishList;
       if (!(listActive.owner && !listActive.users?.length)) {
-        console.log("Set active list infos after ", listActive);
         this.wishService.setWishList(listActive, true, true);
         return true;
       }
-      console.log("Do not set active list infos ", listActive);
     }
-    return this.wishService.getWishListFullInfos(listName).pipe(
-      tap(fullList => {
-        console.log("Set Full List infos after ", fullList);
-        this.wishService.setWishList(fullList, true, true);
-      })
-    );
+    return this.wishService.getWishListFullInfos(listName);
   }
 
   remove(id: ID) {


### PR DESCRIPTION
Cette PR permets de corriger le passage de offrir a offert. Une fois que c'est déjà chargé, on ne recharge pas les envies, pour passer de l'un à l'autre. 

Amélioration aussi du nombre de requête : Il y a avait deux requêtes qui était faite pour récupérer les infos de la liste. Amélioration des temps de requêtes. 

Affichage du nombre d'envie a offrir et offerte dans les onglets (l'onglet arche n'est pas affiché, si il n'y en a pas.). 

Ajout d'un bouton, rafraichire, pour récupérer de nouveaux les envies. 

